### PR TITLE
fix #9 by using LF line-endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,4 @@
+# we want to ensure we're using LF instead of CR+LF as line-endings
+# in the published package, otherwise the bin scripts won't work with
+# yarn - see https://github.com/yarnpkg/yarn/issues/5480
 * text=auto eol=lf


### PR DESCRIPTION
fixes #9 

After merging this in, to actually see the fixed line-endings in your working tree, you'll need to clear out your working directory, and then restore everything again by doing this:

(N.B. this will clear out any uncommitted changes you have on your branch).

```
git rm -r ./* && git reset --hard
```

Then if you open `bin/index.js` you should see that the line-endings are just LF rather than CR+LF. I tested this in Notepad++ (View > Show Symbol > Show End of Line). 
